### PR TITLE
Fix auto-commit permission

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -8,6 +8,8 @@ name: Update manifests
 jobs:
   recent:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I noticed that the workflow failed (https://github.com/hvmzx/ludusavi-manifests/actions/runs/11621818141/job/32366246351) due to a permissions error. I'm not sure why I haven't needed to add this setting in my repos, but I found it in the action documentation (https://github.com/stefanzweifel/git-auto-commit-action), so it should help.

Also, FYI, the Python file's `NON_STEAM_TEMPLATE` will overwrite the changes you made in https://github.com/hvmzx/ludusavi-manifests/commit/e6ae0e08a721b42d562aa728115c5016ebf51617, so you'll probably want to make the same change in the Python file.